### PR TITLE
Converting int to string for uid.

### DIFF
--- a/lib/omniauth/strategies/evernote.rb
+++ b/lib/omniauth/strategies/evernote.rb
@@ -12,7 +12,7 @@ module OmniAuth
         :authorize_path => '/OAuth.action'
       }
 
-      uid { raw_info.id }
+      uid { raw_info.id.to_s }
 
       info do
         {


### PR DESCRIPTION
Omniauth expects uid to be a string, not an integer.
