### PR TITLE
Converted raw_info to hash

### DIFF
--- a/lib/omniauth/strategies/evernote.rb
+++ b/lib/omniauth/strategies/evernote.rb
@@ -32,7 +32,7 @@ module OmniAuth
             userStoreTransport = ::Thrift::HTTPClientTransport.new(userStoreUrl)
             userStoreProtocol = ::Thrift::BinaryProtocol.new(userStoreTransport)
             userStore = ::Evernote::EDAM::UserStore::UserStore::Client.new(userStoreProtocol)
-            userStore.getUser(access_token.token).as_json
+            userStore.getUser(access_token.token).as_json.stringify_keys!
           end
       end
     end

--- a/spec/omniauth/strategies/evernote_spec.rb
+++ b/spec/omniauth/strategies/evernote_spec.rb
@@ -40,7 +40,7 @@ describe OmniAuth::Strategies::Evernote do
   describe "#uid" do
     before do
       subject.stub(:raw_info) do
-        OpenStruct.new('id' => '123')
+        {'id' => '123'}
       end
     end
 
@@ -52,7 +52,7 @@ describe OmniAuth::Strategies::Evernote do
   describe "#info" do
     before :each do
       subject.stub(:raw_info) do
-        OpenStruct.new(:name => "Mike Rotch", :username => "mikerotch")
+        {'name' => "Mike Rotch", 'username' => "mikerotch"}
       end
     end
 


### PR DESCRIPTION
The raw_info field should be a hash rather than a Evernote::EDAM::Type::User object.
