### PR TITLE
fix VERSION constant namespace module name

### DIFF
--- a/lib/omniauth-evernote/version.rb
+++ b/lib/omniauth-evernote/version.rb
@@ -1,4 +1,4 @@
-module Omniauth
+module OmniAuth
   module Evernote
     VERSION = "1.2.1"
   end

--- a/omniauth-evernote.gemspec
+++ b/omniauth-evernote.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "omniauth-evernote"
   gem.require_paths = ["lib"]
-  gem.version       = Omniauth::Evernote::VERSION
+  gem.version       = OmniAuth::Evernote::VERSION
 
   gem.add_runtime_dependency     'omniauth-oauth', '~> 1.0'
   gem.add_runtime_dependency     'evernote-thrift'


### PR DESCRIPTION
[omniauth.gem defines `OmniAuth` module (not `Omniauth`).](https://github.com/omniauth/omniauth/blob/v2.0.4/lib/omniauth.rb#L5)

[`OmniAuth::Strategies::Evernote` is also in `OmniAuth` module.](https://github.com/szimek/omniauth-evernote/blob/v1.2.1/lib/omniauth/strategies/evernote.rb#L6)

But `VERSION` constant is not in `OmniAuth` module. This pull-request fixes it.
